### PR TITLE
fixed lodash case sensitive require statements and bumped lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "immutable": "^3.7.5",
     "lodash.isplainobject": "^3.2.0",
-    "lodash.mapvalues": "^3.0.1"
+    "lodash.mapvalues": "^4.6.0"
   },
   "devDependencies": {
     "babel": "^5.5.8",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import mapValues from 'lodash.mapValues';
-import isPlainObject from 'lodash.isPlainObject';
+import mapValues from 'lodash.mapvalues';
+import isPlainObject from 'lodash.isplainobject';
 import { Iterable } from 'immutable';
 
 export function isImmutable(obj) {


### PR DESCRIPTION
Changes the lodash imports to be case sensitive and bumps lodash version for `mapValues`

This will address build issues on case sensitive operating systems.
